### PR TITLE
Add "day" unit support for startOf/endOf to support minDate/maxDate days component options.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -4,6 +4,7 @@ import {
   addMonths,
   addWeeks,
   differenceInMilliseconds,
+  endOfDay,
   endOfISOWeek,
   endOfMonth,
   format,
@@ -12,6 +13,7 @@ import {
   isAfter as _isAfter,
   isBefore as _isBefore,
   isSameDay,
+  startOfDay,
   startOfISOWeek,
   startOfMonth,
   startOfWeek as _startOfWeek,
@@ -49,6 +51,8 @@ export function startOf(date, unit) {
       return startOfISOWeek(date);
     case "week":
       return _startOfWeek(date);
+    case "day":
+      return startOfDay(date);
     default:
       throw unsupported('startOf', ...arguments);
   }
@@ -60,6 +64,8 @@ export function endOf(date, unit) {
       return endOfMonth(date);
     case "isoWeek":
       return endOfISOWeek(date);
+    case "day":
+      return endOfDay(date);
     default:
       throw unsupported('endOf', ...arguments);
   }


### PR DESCRIPTION
When trying to use the minDate/maxDate configuration options for the days component, currently get an error that the "day" unit isn't supported in startOf().

```
<calendar.Days
  @minDate={{@minDate}}
  @maxDate={{@maxDate}} />
```

This adds "day" unit support for startOf/endOf to support use of the minDate/maxDate days component options.


